### PR TITLE
DTO 들에 Serializable 인터페이스 제거

### DIFF
--- a/src/main/java/com/dpwns/projectboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/dpwns/projectboard/dto/response/ArticleCommentResponse.java
@@ -10,8 +10,7 @@ public record ArticleCommentResponse(
         String content,
         LocalDateTime createdAt,
         String email,
-        String nickname
-) implements Serializable {
+        String nickname){
 
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleCommentResponse(id, content, createdAt, email, nickname);

--- a/src/main/java/com/dpwns/projectboard/dto/response/ArticleResponse.java
+++ b/src/main/java/com/dpwns/projectboard/dto/response/ArticleResponse.java
@@ -12,8 +12,7 @@ public record ArticleResponse(
         String hashtag,
         LocalDateTime createdAt,
         String email,
-        String nickname
-) implements Serializable {
+        String nickname) {
 
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);

--- a/src/main/java/com/dpwns/projectboard/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/dpwns/projectboard/dto/response/ArticleWithCommentsResponse.java
@@ -16,8 +16,7 @@ public record ArticleWithCommentsResponse(
         LocalDateTime createdAt,
         String email,
         String nickname,
-        Set<ArticleCommentResponse> articleCommentsResponse
-) implements Serializable {
+        Set<ArticleCommentResponse> articleCommentsResponse){
 
     public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
         return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);


### PR DESCRIPTION
JPA Buddy 를 이용해 작성한 DTO들인데,
자동으로 `implements Serializable` 이 들어가버림
우리 프로젝트는 직렬화로 Jackson을 사용하므로
필요하지 않고, 의도하여 넣은 코드도 아님
그러므로 삭제