### PR TITLE
fix: Dto에 오타로 인한 에러 발생

### DIFF
--- a/src/main/java/com/dpwns/projectboard/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/dpwns/projectboard/dto/response/ArticleWithCommentsResponse.java
@@ -13,7 +13,7 @@ public record ArticleWithCommentsResponse(
         Long id,
         String title,
         String content,
-        Set<String> hastags,
+        Set<String> hashtags,
         LocalDateTime createdAt,
         String email,
         String nickname,


### PR DESCRIPTION
해시태그 고도화 후 테스트 단계에서 에러가 발생해 확인해보니 오타가 있었다.
hastags -> hashtags로 변경