### PR TITLE
[리팩토링] 잘못된 소스코드 정리

### DIFF
--- a/src/main/java/com/dpwns/projectboard/config/SecurityConfig.java
+++ b/src/main/java/com/dpwns/projectboard/config/SecurityConfig.java
@@ -76,6 +76,18 @@ public class SecurityConfig {
                 .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다."));
     }
 
+    /**
+     * <p>
+     * OAuth 2.0 기술을 이용한 인증 정보를 처리한다.
+     * 카카오 인증 방식을 선택.
+     *
+     * <p>
+     * TODO: 카카오 도메인에 결합되어 있는 코드. 확장을 고려하면 별도 인증 처리 서비스 클래스로 분리하는 것이 좋지만, 현재 다른 OAuth 인증 플랫폼을 사용할 예정이 없어 이렇게 마무리한다.
+     *
+     * @param userAccountService  게시판 서비스의 사용자 계정을 다루는 서비스 로직
+     * @param passwordEncoder 패스워드 암호화 도구
+     * @return {@link OAuth2UserService} OAuth2 인증 사용자 정보를 읽어들이고 처리하는 서비스 인스턴스 반환
+     */
     @Bean
     public OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService(
             UserAccountService userAccountService,

--- a/src/main/java/com/dpwns/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/dpwns/projectboard/domain/UserAccount.java
@@ -42,7 +42,7 @@ public class UserAccount extends AuditingFields {
     }
 
     public static UserAccount of(String userId, String userPassword, String email, String nickname, String memo) {
-        return new UserAccount(userId, userPassword, email, nickname, memo, null);
+        return UserAccount.of(userId, userPassword, email, nickname, memo, null);
     }
 
     public static UserAccount of(String userId, String userPassword, String email, String nickname, String memo, String createBy) {

--- a/src/main/java/com/dpwns/projectboard/dto/security/BoardPrincipal.java
+++ b/src/main/java/com/dpwns/projectboard/dto/security/BoardPrincipal.java
@@ -23,7 +23,7 @@ public record BoardPrincipal(
 ) implements UserDetails, OAuth2User {
 
     public static BoardPrincipal of(String username, String password, String email, String nickname, String memo) {
-        return of(username, password, email, nickname, memo, Map.of());
+        return BoardPrincipal.of(username, password, email, nickname, memo, Map.of());
     }
 
     public static BoardPrincipal of(String username, String password, String email, String nickname, String memo, Map<String, Object> oAuth2Attribute){


### PR DESCRIPTION
* `SecurityConfig`: 줄바꿈 수정. 간단한 Javadoc 문법 소개
* `UserAccount`: `new` 생성자를 `of()` 메소드로 변경
* `BoardPrincipal`: `of()` 메소드에 클래스명까지 작성
잘못 작성된 부분을 수정, 기능은 동일하다

This closes #108 